### PR TITLE
[FINDY-20] chore: postgresql 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,13 +39,12 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.testcontainers:mysql'
+    runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/docker/compose-local.yaml
+++ b/docker/compose-local.yaml
@@ -1,17 +1,16 @@
 services:
   findy-db:
-    image: mysql:8.0
+    image: postgres:latest
     platform: linux/x86_64
     ports:
-      - "3320:3306"
+      - "5433:5432"
     environment:
-      MYSQL_ROOT_PASSWORD: findydb!
-      MYSQL_DATABASE: findy-db
-      MYSQL_USER: findy
-      MYSQL_PASSWORD: findydb!
+      POSTGRES_DB: findy-db
+      POSTGRES_USER: findy
+      POSTGRES_PASSWORD: findydb!
       TZ: Asia/Seoul
     volumes:
-      - ./db/mysql/data:/var/lib/mysql
-      - ./db/mysql/config:/etc/mysql/conf.d
+      - ./db/postgresql/data:/var/lib/postgresql/data
+      - ./db/postgresql/config:/etc/postgresql/conf.d
 networks:
   findy-db-local:

--- a/src/main/java/org/findy/findy_be/common/entity/BaseEntity.java
+++ b/src/main/java/org/findy/findy_be/common/entity/BaseEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.SequenceGenerator;
 import lombok.Getter;
 
 @Getter
@@ -20,7 +21,8 @@ import lombok.Getter;
 public abstract class BaseEntity {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "entity_sequence")
+	@SequenceGenerator(name = "entity_sequence", sequenceName = "entity_seq", allocationSize = 1)
 	private Long id;
 
 	@CreatedDate

--- a/src/main/java/org/findy/findy_be/user/entity/User.java
+++ b/src/main/java/org/findy/findy_be/user/entity/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
 public class User extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.postgresql.Driver
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
@@ -14,7 +14,7 @@ spring:
         default_schema: ${DB_SCHEMA}
         format_sql: true
         highlight_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
     defer-datasource-initialization: false
 
 logging:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,11 +15,11 @@ spring:
       hibernate:
         format_sql: true
         highlight_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3320/findy-db
-    username: root
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5433/findy-db
+    username: findy
     password: findydb!
 
 logging:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -10,10 +10,10 @@ spring:
       hibernate:
         format_sql: true
         highlight_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:tc:mysql:8.0.26:///testdb
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:tc:postgresql:12:///testdb
     username: test
     password: test
 


### PR DESCRIPTION
## ✅ 작업 내용
- 추후에 데이터를 한번에 많이 저장하는 로직이 들어갈 것으로 예상되어 bulk insert를 적용하고자하는데 PostgreSQL이 ID Generator중 시퀀스를 사용한 방식을 적용할 수 있기에 채택하고자했습니다.
- 또한 MySQL은 계층적으로 인덱싱된 데이터를 저장하는 B-트리 및 R-트리 인덱싱을 지원합니다. PostgreSQL 인덱스 유형에는 트리, 표현식 인덱스, 부분 인덱스 및 해시 인덱스가 포함됩니다. 크기를 확장할 때 데이터베이스 성능 요구 사항을 세밀하게 조정할 수 있는 더 많은 옵션이 있습니다.

### Bulk Insert에서 `identity` 전략을 사용하면 안 되는 이유와 `sequence` 전략을 사용할 이유

#### 1. **`identity` 전략**
- **특징**: `identity` 전략은 MySQL, SQL Server, DB2 등에서 주로 사용되며, 데이터베이스가 자동으로 기본 키를 증가시키는 방식입니다. MySQL에서는 주로 `AUTO_INCREMENT`가 이에 해당하며, 각 Insert 시점에 DB에서 자동으로 키를 생성합니다.
- **Bulk Insert와의 문제점**:
    - **Insert 쿼리의 개별 처리**: `identity` 전략을 사용할 경우, 각 레코드가 삽입될 때마다 데이터베이스에서 기본 키를 생성하기 때문에, Insert 쿼리가 **개별적으로** 실행됩니다. 이는 Bulk Insert처럼 한꺼번에 데이터를 삽입하는 작업에서는 비효율적입니다.
    - **성능 저하**: 쿼리가 하나하나 실행되므로, 네트워크 오버헤드가 발생하며, 데이터베이스에 대한 I/O 비용도 높아져 대량의 데이터를 처리할 때 성능 저하가 크게 나타납니다. 특히 수천 수만 개의 데이터를 삽입하는 경우, 이 문제는 더욱 두드러집니다.

#### 2. **`sequence` 전략**
- **특징**: `sequence` 전략은 PostgreSQL, Oracle, SQL Server 등 다양한 DBMS에서 사용되는 방식으로, 고유한 시퀀스를 별도로 생성해 관리합니다. Insert 작업 전 미리 시퀀스를 사용해 기본 키 값을 할당한 후, 그 키를 이용해 데이터를 삽입하는 방식입니다.
- **Bulk Insert와의 호환성**:
    - **대량 처리에 유리**: 시퀀스를 통해 미리 키 값을 생성할 수 있기 때문에, 여러 레코드를 한꺼번에 삽입할 때도 각 레코드의 기본 키 값을 미리 할당할 수 있습니다. 이로 인해 Bulk Insert 시 여러 레코드를 하나의 Insert 쿼리로 처리할 수 있어 성능이 크게 향상됩니다.
    - **성능 향상**: `sequence` 전략은 데이터를 한 번에 처리할 수 있어 Insert 작업을 최적화할 수 있습니다. 또한, 쿼리가 DB에 개별적으로 전달되지 않고 일괄적으로 처리되므로, 네트워크 및 I/O 오버헤드가 줄어들어 성능 이점이 큽니다.

---

### MySQL에서 PostgreSQL로 넘어간 이유

#### 1. **`identity` vs `sequence` 전략의 차이**
   - **MySQL**: MySQL은 기본적으로 `AUTO_INCREMENT`와 같은 `identity` 전략을 사용하여 기본 키를 생성합니다. 그러나 이 방식은 Bulk Insert와 같은 대량 데이터 삽입 시, 개별 Insert 쿼리가 발생하기 때문에 성능이 떨어집니다.
   - **PostgreSQL**: PostgreSQL은 `sequence` 전략을 사용하여 기본 키를 관리하며, 시퀀스를 통해 미리 키 값을 할당받아 대량 데이터를 한꺼번에 삽입할 수 있습니다. 이로 인해 Bulk Insert에서 성능 최적화가 가능해집니다.

#### 2. **PostgreSQL의 성능 이점**
   - **대량 데이터 처리 성능**: PostgreSQL은 시퀀스를 통해 Bulk Insert에 적합하며, 대량 데이터를 처리할 때 뛰어난 성능을 제공합니다. 기본 키 생성을 미리 처리해 대규모 삽입 작업에서 성능 이점을 누릴 수 있습니다.
   - **동시성 처리**: PostgreSQL은 높은 동시성을 처리할 수 있는 구조로 설계되어, 다수의 트랜잭션이 동시에 발생해도 성능 저하가 적습니다. 대량 데이터 처리와 동시성 성능에서 PostgreSQL이 우수한 이유입니다.
   - **복잡한 쿼리 최적화**: PostgreSQL은 복잡한 쿼리를 효율적으로 처리할 수 있으며, JSON 데이터 처리와 같은 현대적 요구 사항에 대응할 수 있는 다양한 기능을 제공합니다.

#### 3. **PostgreSQL로의 전환 이유**
   - MySQL에서 PostgreSQL로 넘어간 주된 이유는 `sequence` 전략을 사용해 대량 데이터 삽입에서 **성능을 최적화**할 수 있기 때문입니다. MySQL의 `identity` 전략은 대량 데이터 처리에 있어 비효율적일 수 있으므로, 성능 향상이 필요한 경우 PostgreSQL의 `sequence` 전략이 더 적합합니다.
   - PostgreSQL은 또한 **확장성**, **복잡한 쿼리 처리 능력**, **동시성 처리** 등에서 장점을 가지며, 대용량 트랜잭션 처리 시스템에 더 적합한 선택일 수 있습니다.

---

### 요약

- **`identity` 전략**은 각 레코드마다 개별적으로 기본 키를 생성하는 방식으로, Bulk Insert 시 **성능 저하**를 초래할 수 있습니다. 
- **`sequence` 전략**은 미리 시퀀스를 통해 기본 키 값을 할당받아 대량의 데이터를 한 번에 삽입할 수 있어, **Bulk Insert**에 최적화된 성능을 제공합니다.
- **PostgreSQL**로 전환한 이유는 `sequence` 전략을 통한 **성능 최적화**뿐만 아니라, **대용량 데이터 처리**, **동시성 처리** 및 **복잡한 쿼리 최적화**와 같은 여러 측면에서 우수한 기능을 제공하기 때문입니다.

- 이러한 이유로 PostgreSQL로 변경하게되었습니다.
