### PR TITLE
[FINDY-67] feat: user-bookmark init

### DIFF
--- a/src/main/java/org/findy/findy_be/FindyBeApplication.java
+++ b/src/main/java/org/findy/findy_be/FindyBeApplication.java
@@ -1,6 +1,6 @@
 package org.findy.findy_be;
 
-import org.findy.findy_be.auth.entity.CorsProperties;
+import org.findy.findy_be.auth.properties.CorsProperties;
 import org.findy.findy_be.common.config.AppProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/org/findy/findy_be/auth/api/AuthController.java
+++ b/src/main/java/org/findy/findy_be/auth/api/AuthController.java
@@ -1,9 +1,9 @@
-package org.findy.findy_be.auth.controller;
+package org.findy.findy_be.auth.api;
 
 import java.util.Date;
 
-import org.findy.findy_be.auth.entity.AuthRequestModel;
-import org.findy.findy_be.auth.oauth.entity.UserPrincipal;
+import org.findy.findy_be.auth.dto.AuthRequestModel;
+import org.findy.findy_be.auth.oauth.domain.UserPrincipal;
 import org.findy.findy_be.auth.oauth.token.AuthToken;
 import org.findy.findy_be.auth.oauth.token.AuthTokenProvider;
 import org.findy.findy_be.common.config.AppProperties;

--- a/src/main/java/org/findy/findy_be/auth/dto/AuthRequestModel.java
+++ b/src/main/java/org/findy/findy_be/auth/dto/AuthRequestModel.java
@@ -1,4 +1,4 @@
-package org.findy.findy_be.auth.entity;
+package org.findy.findy_be.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/findy/findy_be/auth/oauth/domain/SocialProviderType.java
+++ b/src/main/java/org/findy/findy_be/auth/oauth/domain/SocialProviderType.java
@@ -1,4 +1,4 @@
-package org.findy.findy_be.auth.oauth.entity;
+package org.findy.findy_be.auth.oauth.domain;
 
 import lombok.Getter;
 

--- a/src/main/java/org/findy/findy_be/auth/oauth/domain/UserPrincipal.java
+++ b/src/main/java/org/findy/findy_be/auth/oauth/domain/UserPrincipal.java
@@ -1,4 +1,4 @@
-package org.findy.findy_be.auth.oauth.entity;
+package org.findy.findy_be.auth.oauth.domain;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/org/findy/findy_be/auth/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/org/findy/findy_be/auth/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
 
-import org.findy.findy_be.auth.oauth.entity.SocialProviderType;
+import org.findy.findy_be.auth.oauth.domain.SocialProviderType;
 import org.findy.findy_be.auth.oauth.info.OAuth2UserInfo;
 import org.findy.findy_be.auth.oauth.info.OAuth2UserInfoFactory;
 import org.findy.findy_be.auth.oauth.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;

--- a/src/main/java/org/findy/findy_be/auth/oauth/info/OAuth2UserInfoFactory.java
+++ b/src/main/java/org/findy/findy_be/auth/oauth/info/OAuth2UserInfoFactory.java
@@ -2,7 +2,7 @@ package org.findy.findy_be.auth.oauth.info;
 
 import java.util.Map;
 
-import org.findy.findy_be.auth.oauth.entity.SocialProviderType;
+import org.findy.findy_be.auth.oauth.domain.SocialProviderType;
 import org.findy.findy_be.auth.oauth.info.implement.KakaoOAuth2UserInfo;
 import org.findy.findy_be.auth.oauth.info.implement.NaverOAuth2UserInfo;
 

--- a/src/main/java/org/findy/findy_be/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/findy/findy_be/auth/oauth/service/CustomOAuth2UserService.java
@@ -2,8 +2,8 @@ package org.findy.findy_be.auth.oauth.service;
 
 import java.time.LocalDateTime;
 
-import org.findy.findy_be.auth.oauth.entity.SocialProviderType;
-import org.findy.findy_be.auth.oauth.entity.UserPrincipal;
+import org.findy.findy_be.auth.oauth.domain.SocialProviderType;
+import org.findy.findy_be.auth.oauth.domain.UserPrincipal;
 import org.findy.findy_be.auth.oauth.info.OAuth2UserInfo;
 import org.findy.findy_be.auth.oauth.info.OAuth2UserInfoFactory;
 import org.findy.findy_be.common.exception.custom.OAuthProviderMissMatchException;

--- a/src/main/java/org/findy/findy_be/auth/oauth/service/CustomUserDetailsService.java
+++ b/src/main/java/org/findy/findy_be/auth/oauth/service/CustomUserDetailsService.java
@@ -2,7 +2,7 @@ package org.findy.findy_be.auth.oauth.service;
 
 import static org.findy.findy_be.common.exception.ErrorCode.*;
 
-import org.findy.findy_be.auth.oauth.entity.UserPrincipal;
+import org.findy.findy_be.auth.oauth.domain.UserPrincipal;
 import org.findy.findy_be.user.entity.User;
 import org.findy.findy_be.user.repository.UserRepository;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/org/findy/findy_be/auth/properties/CorsProperties.java
+++ b/src/main/java/org/findy/findy_be/auth/properties/CorsProperties.java
@@ -1,4 +1,4 @@
-package org.findy.findy_be.auth.entity;
+package org.findy.findy_be.auth.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/org/findy/findy_be/bookmark/api/BookmarkController.java
+++ b/src/main/java/org/findy/findy_be/bookmark/api/BookmarkController.java
@@ -1,0 +1,15 @@
+package org.findy.findy_be.bookmark.api;
+
+import org.findy.findy_be.bookmark.application.BookmarkService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/bookmarks")
+public class BookmarkController {
+
+	private final BookmarkService bookmarkService;
+}

--- a/src/main/java/org/findy/findy_be/bookmark/application/BookmarkService.java
+++ b/src/main/java/org/findy/findy_be/bookmark/application/BookmarkService.java
@@ -1,0 +1,24 @@
+package org.findy.findy_be.bookmark.application;
+
+import java.util.List;
+
+import org.findy.findy_be.bookmark.domain.Bookmark;
+import org.findy.findy_be.bookmark.repository.BookmarkRepository;
+import org.findy.findy_be.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BookmarkService {
+
+	private final BookmarkRepository bookmarkRepository;
+
+	public void initBookmarks(User user) {
+		List<Bookmark> bookmarks = Bookmark.initBookmarks(user);
+		bookmarkRepository.saveAll(bookmarks);
+	}
+}

--- a/src/main/java/org/findy/findy_be/bookmark/domain/Bookmark.java
+++ b/src/main/java/org/findy/findy_be/bookmark/domain/Bookmark.java
@@ -1,0 +1,55 @@
+package org.findy.findy_be.bookmark.domain;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.findy.findy_be.common.entity.BaseEntity;
+import org.findy.findy_be.user.entity.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "bookmarks")
+public class Bookmark extends BaseEntity {
+
+	private String name;
+
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	private MajorCategory majorCategory;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	public static Bookmark of(String name, MajorCategory majorCategory, User user) {
+		return Bookmark.builder()
+			.name(name)
+			.majorCategory(majorCategory)
+			.user(user)
+			.build();
+	}
+
+	public static List<Bookmark> initBookmarks(User user) {
+		return Stream.of(MajorCategory.values())
+			.map(category -> Bookmark.of(category.getLabel(), category, user))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/org/findy/findy_be/bookmark/domain/MajorCategory.java
+++ b/src/main/java/org/findy/findy_be/bookmark/domain/MajorCategory.java
@@ -1,0 +1,17 @@
+package org.findy.findy_be.bookmark.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Schema(description = "즐겨찾기 대분류", enumAsRef = true)
+@Getter
+@RequiredArgsConstructor
+public enum MajorCategory {
+
+	RESTAURANT("음식점"),
+	TRAVEL_AND_ATTRACTION("여행,명소"),
+	SHOPPING_AND_DISTRIBUTION("쇼핑,유통");
+
+	private final String label;
+}

--- a/src/main/java/org/findy/findy_be/bookmark/domain/MiddleCategory.java
+++ b/src/main/java/org/findy/findy_be/bookmark/domain/MiddleCategory.java
@@ -1,0 +1,18 @@
+package org.findy.findy_be.bookmark.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Schema(description = "즐겨찾기 중분류", enumAsRef = true)
+@Getter
+@RequiredArgsConstructor
+public enum MiddleCategory {
+
+	KOREAN(MajorCategory.RESTAURANT, "한식"),
+	CHINESE(MajorCategory.RESTAURANT, "중식"),
+	JAPANESE(MajorCategory.RESTAURANT, "일식");
+
+	private final MajorCategory majorCategory;
+	private final String label;
+}

--- a/src/main/java/org/findy/findy_be/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/findy/findy_be/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package org.findy.findy_be.bookmark.repository;
+
+import org.findy.findy_be.bookmark.domain.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+}

--- a/src/main/java/org/findy/findy_be/common/config/SecurityConfig.java
+++ b/src/main/java/org/findy/findy_be/common/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package org.findy.findy_be.common.config;
 
 import java.util.Arrays;
 
-import org.findy.findy_be.auth.entity.CorsProperties;
 import org.findy.findy_be.auth.oauth.filter.TokenAuthenticationFilter;
 import org.findy.findy_be.auth.oauth.handler.OAuth2AuthenticationFailureHandler;
 import org.findy.findy_be.auth.oauth.handler.OAuth2AuthenticationSuccessHandler;
@@ -11,6 +10,7 @@ import org.findy.findy_be.auth.oauth.repository.OAuth2AuthorizationRequestBasedO
 import org.findy.findy_be.auth.oauth.service.CustomOAuth2UserService;
 import org.findy.findy_be.auth.oauth.service.CustomUserDetailsService;
 import org.findy.findy_be.auth.oauth.token.AuthTokenProvider;
+import org.findy.findy_be.auth.properties.CorsProperties;
 import org.findy.findy_be.user.repository.UserRefreshTokenRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/org/findy/findy_be/user/api/UserController.java
+++ b/src/main/java/org/findy/findy_be/user/api/UserController.java
@@ -1,8 +1,8 @@
-package org.findy.findy_be.user.controller;
+package org.findy.findy_be.user.api;
 
 import org.findy.findy_be.common.meta.LoginUser;
+import org.findy.findy_be.user.application.UserService;
 import org.findy.findy_be.user.entity.User;
-import org.findy.findy_be.user.service.UserService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/org/findy/findy_be/user/api/UserController.java
+++ b/src/main/java/org/findy/findy_be/user/api/UserController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/src/main/java/org/findy/findy_be/user/application/UserService.java
+++ b/src/main/java/org/findy/findy_be/user/application/UserService.java
@@ -1,4 +1,4 @@
-package org.findy.findy_be.user.service;
+package org.findy.findy_be.user.application;
 
 import org.findy.findy_be.user.entity.User;
 import org.findy.findy_be.user.repository.UserRepository;

--- a/src/main/java/org/findy/findy_be/user/entity/User.java
+++ b/src/main/java/org/findy/findy_be/user/entity/User.java
@@ -2,7 +2,7 @@ package org.findy.findy_be.user.entity;
 
 import java.time.LocalDateTime;
 
-import org.findy.findy_be.auth.oauth.entity.SocialProviderType;
+import org.findy.findy_be.auth.oauth.domain.SocialProviderType;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 

--- a/src/main/java/org/findy/findy_be/user/entity/User.java
+++ b/src/main/java/org/findy/findy_be/user/entity/User.java
@@ -1,13 +1,18 @@
 package org.findy.findy_be.user.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.findy.findy_be.auth.oauth.domain.SocialProviderType;
+import org.findy.findy_be.auth.oauth.info.OAuth2UserInfo;
+import org.findy.findy_be.bookmark.domain.Bookmark;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,16 +20,17 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
@@ -32,47 +38,47 @@ import lombok.Setter;
 public class User {
 	@JsonIgnore
 	@Id
-	@Column(name = "USER_SEQ")
+	@Column(name = "user_seq")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long userSeq;
 
-	@Column(name = "USER_ID", length = 64, unique = true)
+	@Column(name = "user_id", length = 64, unique = true)
 	@NotNull
 	@Size(max = 64)
 	private String userId;
 
-	@Column(name = "USERNAME", length = 100)
+	@Column(name = "username", length = 100)
 	@NotNull
 	@Size(max = 100)
 	private String username;
 
 	@JsonIgnore
-	@Column(name = "PASSWORD", length = 128)
+	@Column(name = "password", length = 128)
 	@NotNull
 	@Size(max = 128)
 	private String password;
 
-	@Column(name = "EMAIL", length = 512, unique = true)
+	@Column(name = "email", length = 512, unique = true)
 	@NotNull
 	@Size(max = 512)
 	private String email;
 
-	@Column(name = "EMAIL_VERIFIED_YN", length = 1)
+	@Column(name = "email_verified_yn", length = 1)
 	@NotNull
 	@Size(min = 1, max = 1)
 	private String emailVerifiedYn;
 
-	@Column(name = "PROFILE_IMAGE_URL", length = 512)
+	@Column(name = "profile_image_url", length = 512)
 	@NotNull
 	@Size(max = 512)
 	private String profileImageUrl;
 
-	@Column(name = "PROVIDER_TYPE", length = 20)
+	@Column(name = "provider_type", length = 20)
 	@Enumerated(EnumType.STRING)
 	@NotNull
 	private SocialProviderType socialProviderType;
 
-	@Column(name = "ROLE_TYPE", length = 20)
+	@Column(name = "role_type", length = 20)
 	@Enumerated(EnumType.STRING)
 	@NotNull
 	private RoleType roleType;
@@ -85,7 +91,20 @@ public class User {
 	@Column(columnDefinition = "TIMESTAMP", name = "updated_at")
 	private LocalDateTime updatedAt;
 
-	public User(
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+	private List<Bookmark> bookmarks = new ArrayList<>();
+
+	public void updateUser(OAuth2UserInfo userInfo) {
+		if (userInfo.getName() != null && !this.username.equals(userInfo.getName())) {
+			this.username = userInfo.getName();
+		}
+
+		if (userInfo.getImageUrl() != null && !this.profileImageUrl.equals(userInfo.getImageUrl())) {
+			this.profileImageUrl = userInfo.getImageUrl();
+		}
+	}
+
+	public static User create(
 		@NotNull @Size(max = 64) String userId,
 		@NotNull @Size(max = 100) String username,
 		@NotNull @Size(max = 512) String email,
@@ -96,15 +115,19 @@ public class User {
 		@NotNull LocalDateTime createdAt,
 		@NotNull LocalDateTime updatedAt
 	) {
-		this.userId = userId;
-		this.username = username;
-		this.password = "NO_PASS";
-		this.email = email != null ? email : "NO_EMAIL";
-		this.emailVerifiedYn = emailVerifiedYn;
-		this.profileImageUrl = profileImageUrl != null ? profileImageUrl : "";
-		this.socialProviderType = socialProviderType;
-		this.roleType = roleType;
-		this.createdAt = createdAt;
-		this.updatedAt = updatedAt;
+		email = email != null ? email : "NO_EMAIL";
+		profileImageUrl = profileImageUrl != null ? profileImageUrl : "";
+		return User.builder()
+			.userId(userId)
+			.username(username)
+			.password("NO_PASS")
+			.email(email)
+			.emailVerifiedYn(emailVerifiedYn)
+			.profileImageUrl(profileImageUrl)
+			.socialProviderType(socialProviderType)
+			.roleType(roleType)
+			.createdAt(createdAt)
+			.updatedAt(updatedAt)
+			.build();
 	}
 }


### PR DESCRIPTION
## ✅ 작업 내용
- User 도메인과 Bookmark 도메인의 초기 entity 및 repository를 추가했습니다.
- repository는 MVP를 빠르게 만들기 위해 JPA Repository를 선택했습니다.
- User를 새롭게 생성할 경우 대분류 Bookmark를 미리 만들어두는 전략을 사용하기 위해 User 생성시점에 BookService의 의존성을 추가했습니다.

## 🤔 고민 했던 부분
- BookRepository의 의존성을 둘지 Service에 둘지 고민했으나 추후에 Bookmark를 여럿 insert할 일이 발생할 가능성이 있고, CustomOAuth2UserService에서 Repository에 접근하는 것보다 Service의 한정된 기능을 사용할 수 있도록 제약을 두는것이 맞다고 판단했습니다.
- Bookmark의 대분류별로 만들게 되는데, 이 Bookmark를 초기화하는 역할을 Bookmark 도메인에 두면서 추후에 발생할 예외처리에도 유연하게 대처할 수 있습니다.